### PR TITLE
SPMUtility to SwiftToolsSupport dependency update

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,13 +13,14 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
          .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.5.0"),
          .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+         .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.1.12"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "onair",
-            dependencies: ["SPMUtility", "Logging"]),
+            dependencies: ["SwiftToolsSupport", "Logging"]),
         .testTarget(
             name: "onairTests",
             dependencies: ["onair"]),

--- a/Sources/onair/main.swift
+++ b/Sources/onair/main.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2019 evenflow. All rights reserved.
 //
 import Cocoa
-import SPMUtility
-import Basic
+import TSCUtility
+import TSCBasic
 import Logging
 
 let logger = Logger(label: "nl.evenflow.onair")


### PR DESCRIPTION
Wasn't building, seems that SPMUtility was moved to a new package